### PR TITLE
Remover override option (now default) and optimized style processing w. r. t. custom styles

### DIFF
--- a/Constants.lua
+++ b/Constants.lua
@@ -492,9 +492,9 @@ ThreatPlates.DEFAULT_SETTINGS = {
       HideNormal = false,
       HideBoss = false,
       HideElite = false,
+      HideGuardian = false,
       HideTapped = false,
       HideFriendlyInCombat = false,
-      HideGuardian = false,
     },
     castbarColor = {
       -- toggle = true, -- removed in 8.7.0
@@ -769,7 +769,6 @@ ThreatPlates.DEFAULT_SETTINGS = {
     },
     uniqueWidget = {
       ON = true,
-      override = true,
       scale = 22, -- old default: 35,
       x = 0,
       y = 30, -- old default:  24,

--- a/Options.lua
+++ b/Options.lua
@@ -4431,7 +4431,8 @@ local function CreateVisibilitySettings()
           HideElite = { name = L["Rares & Elites"], order = 2, type = "toggle", arg = { "Visibility", "HideElite" }, },
           HideBoss = { name = L["Bosses"], order = 3, type = "toggle", arg = { "Visibility", "HideBoss" }, },
           HideTapped = { name = L["Tapped Units"], order = 4, type = "toggle", arg = { "Visibility", "HideTapped" }, },
-		  HideGuardian = { name = L["Guardian Units"], order = 5, type = "toggle", arg = { "Visibility", "HideGuardian" }, },
+		      HideGuardian = { name = L["Guardian Units"], order = 5, type = "toggle", arg = { "Visibility", "HideGuardian" }, },
+          Spacer1 = GetSpacerEntry(9),
           ModeHideFriendlyInCombat = {
             name = L["Friendly Units in Combat"],
             order = 10,
@@ -7134,21 +7135,6 @@ local function CreateCustomNameplatesGroup()
       type = "group",
       order = 30,
       args = {
-		General = {
-          name = L["General"],
-          type = "group",
-          order = 1,
-          inline = true,
-          args = {
-			Override = {
-				name = L["Override General Hide Settings"],
-				type = "toggle",
-				order = 1,
-				desc = 'Toggle this option if you want the custom nameplates to be able to override general settings (e.g. the "Hide Nameplate" settings)',
-				arg = { "uniqueWidget", "override" }
-			},
-          },
-        },
         Icon = {
           name = L["Icon"],
           type = "group",

--- a/Styles/Styles.lua
+++ b/Styles/Styles.lua
@@ -7,7 +7,7 @@ local ThreatPlates = Addon.ThreatPlates
 
 -- WoW APIs
 local InCombatLockdown, IsInInstance = InCombatLockdown, IsInInstance
-local UnitPlayerControlled, UnitIsUnit = UnitPlayerControlled, UnitIsUnit
+local UnitIsPlayer, UnitPlayerControlled, UnitIsUnit = UnitIsPlayer, UnitPlayerControlled, UnitIsUnit
 local UnitIsOtherPlayersPet = UnitIsOtherPlayersPet
 local UnitIsBattlePet = UnitIsBattlePet
 local UnitCanAttack = UnitCanAttack
@@ -138,21 +138,21 @@ local function ShowUnit(unit)
   local unit_type = GetUnitType(unit)
   local show, headline_view = GetUnitVisibility(unit_type)
 
-  if not show then return false end
+  if not show then return false, false end
 
-  local e, b, t, g = (unit.isElite or unit.isRare), unit.isBoss, _G.UnitIsTapDenied(unit.unitid), (not UnitIsPlayer(unit.unitid) and UnitPlayerControlled(unit.unitid) and not UnitIsOtherPlayersPet(unit.unitid))
+  local e, b = (unit.isElite or unit.isRare), unit.isBoss
   local db_base = TidyPlatesThreat.db.profile
   local db = db_base.Visibility
 
-  if (e and db.HideElite) or (b and db.HideBoss) or (t and db.HideTapped) or (g and db.HideGuardian) then
-    return false
+  if (e and db.HideElite) or (b and db.HideBoss) or (unit.TP_DetailedUnitType == "Tapped" and db.HideTapped) or (unit.TP_DetailedUnitType == "Guardian" and db.HideGuardian) then
+    return false, nil
   elseif db.HideNormal and not (e or b) then
-    return false
+    return false, nil
   elseif UnitIsBattlePet(unit.unitid) then
     -- TODO: add configuration option for enable/disable
-    return false
+    return false, nil
   elseif db.HideFriendlyInCombat and unit.reaction == "FRIENDLY" and InCombatLockdown() then
-    return false
+    return false, nil
   end
 
 --  if full_unit_type == "EnemyNPC" then
@@ -321,34 +321,18 @@ end
 function Addon:SetStyle(unit)
   local show, headline_view = ShowUnit(unit)
 
-  local db_base = TidyPlatesThreat.db.profile
-  local db = db_base.uniqueWidget
-
-  if not db.override then
-	  if not show then
-		return "empty", nil
-	  end
-  end
-  
   -- Check if custom nameplate should be used for the unit:
   local style
   if unit.CustomStyleCast then
-	style = unit.CustomStyleCast
-	unit.CustomPlateSettings = unit.CustomPlateSettingsCast
+    style = unit.CustomStyleCast
+    unit.CustomPlateSettings = unit.CustomPlateSettingsCast
   elseif unit.CustomStyleAura then
-	style = unit.CustomStyleAura
-	unit.CustomPlateSettings = unit.CustomPlateSettingsAura
+    style = unit.CustomStyleAura
+    unit.CustomPlateSettings = unit.CustomPlateSettingsAura
   else
-	style = UnitStyle_NameDependent(unit) or (headline_view and "NameOnly")
+  	style = UnitStyle_NameDependent(unit) or (headline_view and "NameOnly")
   end
 	  
-  if db.override then
-	if not show and not (style ~= nil and not (type(style) == string and (style == "unique"))) then
-		return "empty", nil
-	end
-  end
-	
-
   -- Dynamic enable checks for custom styles
   -- Only check it once if custom style is used for multiple mobs
   -- only check it once when entering a dungeon, not on every style change
@@ -368,7 +352,12 @@ function Addon:SetStyle(unit)
     end
   end
 
-  --if not style and unit.reaction ~= "FRIENDLY" then
+  -- headline_view == nil  (and not show) means that the unit should be hidden (Visibility - Hide Nameplates)
+  --if not show and headline_view == nil and not (style == "unique" or style == "NameOnly-Unique") then
+  if not (show or headline_view ~= nil or style == "unique" or style == "NameOnly-Unique") then
+    return "empty", nil
+  end
+
   if not style and Addon:ShowThreatFeedback(unit) then
     -- could call GetThreatStyle here, but that would at a tiny overhead
     -- style tank/dps only used for hostile (enemy, neutral) NPCs


### PR DESCRIPTION
- Removed the override option as it does make more sense to let override be the default behaviour and enable/disable custom styles as needed
- Moved override check after instance check so that custom styles disabled in instances (or outside) are handled currectly.
- Optimized code for style handling